### PR TITLE
Prevent crash when trying to open database

### DIFF
--- a/library/src/com/orm/Database.java
+++ b/library/src/com/orm/Database.java
@@ -13,16 +13,18 @@ public class Database {
     }
 
 
-  public SQLiteDatabase openDB() {
-    this.sqLiteDatabase = this.sugarDb.getWritableDatabase();
+    public SQLiteDatabase openDB() {
+        if (this.sqLiteDatabase == null) {
+            this.sqLiteDatabase = this.sugarDb.getWritableDatabase();
+        }
 
-    return this.sqLiteDatabase;
-  }
-
-  public void closeDB() {
-    if (this.sqLiteDatabase != null) {
-      this.sqLiteDatabase.close();
-      this.sqLiteDatabase = null;
+        return this.sqLiteDatabase;
     }
-  }
+
+    public void closeDB() {
+        if (this.sqLiteDatabase != null) {
+            this.sqLiteDatabase.close();
+            this.sqLiteDatabase = null;
+        }
+    }
 }


### PR DESCRIPTION
When the database has already been opened, don't try reopening it.
Instead, just return the current reference.
