### PR TITLE
Fix migrations: only the first line in the migration script is executed

### DIFF
--- a/library/src/com/orm/SugarDb.java
+++ b/library/src/com/orm/SugarDb.java
@@ -176,20 +176,18 @@ public class SugarDb extends SQLiteOpenHelper {
     }
 
     private void executeScript(SQLiteDatabase db, String file) {
-        StringBuilder text = new StringBuilder();
         try {
             InputStream is = this.context.getAssets().open("sugar_upgrades/" + file);
             BufferedReader reader = new BufferedReader(new InputStreamReader(is));
             String line;
             while ((line = reader.readLine()) != null) {
-                text.append(line);
-                text.append("\n");
+                Log.i("Sugar script", line);
+                db.execSQL(line.toString());
             }
         } catch (IOException e) {
             Log.e("Sugar", e.getMessage());
         }
 
-        Log.i("Sugar", "script : " + text.toString());
-        db.execSQL(text.toString());
+        Log.i("Sugar", "script executed");
     }
 }


### PR DESCRIPTION
The `execSQL()` documentation states that

```
Multiple statements separated by semicolons are not supported
```

so when the migrations scripts are used, only the first line is executed.
