### PR TITLE
Add strict count overload to simplify interface

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -222,6 +222,10 @@ public class SugarRecord<T>{
         }
         return toRet;
     }
+
+    public static <T extends SugarRecord<?>> long count(Class<?> type) {
+        return count(type, null, null, null, null, null);
+    }
     
     public static <T extends SugarRecord<?>> long count(Class<?> type,
             String whereClause, String[] whereArgs) {


### PR DESCRIPTION
Convenience method to clarify public interface to counts of items in a particular table.

Closes #54.
