### PR TITLE
Return id by default on save

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -43,8 +43,8 @@ public class SugarRecord<T>{
         sqLiteDatabase.delete(getTableName(type), whereClause, whereArgs);
     }
 
-    public void save() {
-        save(getSugarContext().getDatabase().getDB());
+    public long save() {
+        return save(getSugarContext().getDatabase().getDB());
     }
 
     @SuppressWarnings("deprecation")
@@ -72,7 +72,7 @@ public class SugarRecord<T>{
 
     }
 
-    void save(SQLiteDatabase db) {
+    long save(SQLiteDatabase db) {
 
         List<Field> columns = getTableFields();
         ContentValues values = new ContentValues(columns.size());
@@ -130,6 +130,7 @@ public class SugarRecord<T>{
             db.update(getSqlName(), values, "ID = ?", new String[]{String.valueOf(id)});
 
         Log.i("Sugar", getClass().getSimpleName() + " saved : " + id);
+        return id;
     }
 
     public static <T extends SugarRecord<?>> List<T> listAll(Class<T> type) {


### PR DESCRIPTION
It's pretty safe to return `id` after a save. This should be the default behavior -- no one should have to wrap `save()` or call an extra method if the `id` is readily available.

Closes #43.
