### PR TITLE
Overload findById to take an Integer

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -142,6 +142,10 @@ public class SugarRecord<T>{
         return list.get(0);
     }
 
+    public static <T extends SugarRecord<?>> T findById(Class<T> type, Integer id) {
+        return findById(type, Long.valueOf(id));
+    }
+
     public static <T extends SugarRecord<?>> Iterator<T> findAll(Class<T> type) {
         return findAsIterator(type, null, null, null, null, null);
     }


### PR DESCRIPTION
Quality of life improvement so users don't have to append an `L` to their primitive integers, or explicitly cast to `Long` when using `findById`. Also makes the interface consistent with all of the example code in the official documentation and README.
