### PR TITLE
Improved documentation and cleaned up NamingHelper

### DIFF
--- a/library/src/com/orm/util/NamingHelper.java
+++ b/library/src/com/orm/util/NamingHelper.java
@@ -1,44 +1,50 @@
 package com.orm.util;
 
+import android.text.TextUtils;
+
 import com.orm.dsl.Column;
 import com.orm.dsl.Table;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 public class NamingHelper {
-    public static String toSQLNameDefault(String javaNotation) {
-        if (javaNotation.equalsIgnoreCase("_id"))
+
+
+    /**
+     * Converts a given CamelCasedString to UPPER_CASE_UNDER_SCORE
+     * @param camelCased a non empty camelCased string
+     * @return the equivalent string converted to UPPER_CASE_UNDER_SCORE unless camelCased equals "_id"
+     * (not case sensitive) in which case "_id" is returned.
+     */
+    public static String toSQLNameDefault(String camelCased) {
+
+        if (camelCased.equalsIgnoreCase("_id"))
             return "_id";
 
-        StringBuilder sb = new StringBuilder();
-        char[] buf = javaNotation.toCharArray();
-
-        for (int i = 0; i < buf.length; i++) {
-            char prevChar = (i > 0) ? buf[i - 1] : 0;
-            char c = buf[i];
-            char nextChar = (i < buf.length - 1) ? buf[i + 1] : 0;
-            boolean isFirstChar = (i == 0);
-
-            if (isFirstChar || Character.isLowerCase(c) || Character.isDigit(c)) {
-                sb.append(Character.toUpperCase(c));
-            } else if (Character.isUpperCase(c)) {
-                if (Character.isLetterOrDigit(prevChar)) {
-                    if (Character.isLowerCase(prevChar)) {
-                        sb.append('_').append(Character.toUpperCase(c));
-                    } else if (nextChar > 0 && Character.isLowerCase(nextChar)) {
-                        sb.append('_').append(Character.toUpperCase(c));
-                    } else {
-                        sb.append(c);
-                    }
-                } else {
-                    sb.append(c);
-                }
+        List<String> words = new LinkedList<String>();
+        StringBuilder currentWord = new StringBuilder();
+        for(int i=0; i< camelCased.length(); i++){
+            char c = camelCased.charAt(i);
+            if(Character.isUpperCase(c)){
+                if(currentWord.length() == 0) words.add(currentWord.toString());
+                currentWord = new StringBuilder();
             }
+            currentWord.append(Character.toUpperCase(c));
         }
-
-        return sb.toString();
+        return TextUtils.join("_", words);
     }
 
+    /**
+     * Maps a Java Field object to the data base's column name.
+     * @param field the Field that will be mapped.
+     * @return the name of the given Field. If the Field is annotated with {@link com.orm.dsl.Column}
+     *         then the {@link com.orm.dsl.Column#name() name()} will be returned if not then the Field's
+     *         {@link java.lang.reflect.Field#getName() getName()} will be converted from CamelCase to
+     *         UNDER_SCORE notation.
+     */
     public static String toSQLName(Field field) {
         if (field.isAnnotationPresent(Column.class)) {
             Column annotation = field.getAnnotation(Column.class);
@@ -48,6 +54,13 @@ public class NamingHelper {
         return toSQLNameDefault(field.getName());
     }
 
+    /**
+     * Maps a Java Class to the name of the class.
+     * @param table the table
+     * @return if the given class is annotated with {@link com.orm.dsl.Table} then the value for
+     *         {@link com.orm.dsl.Table#name() name()} will be returned, if not then the class' simple name
+     *         will be converted from CamelCase to UNDER_SCORE.
+      */
     public static String toSQLName(Class<?> table) {
 
         if (table.isAnnotationPresent(Table.class)) {

--- a/library/test/com/orm/NamingHelperTest.java
+++ b/library/test/com/orm/NamingHelperTest.java
@@ -8,18 +8,28 @@ import static junit.framework.Assert.assertEquals;
 public class NamingHelperTest {
     @Test
     public void testToSQLNameCaseConversion() throws Exception {
-        assertEquals("TESTLOWERCASE", NamingHelper.toSQLNameDefault("testlowercase"));
-        assertEquals("TESTUPPERCASE", NamingHelper.toSQLNameDefault("TESTUPPERCASE"));
+        assertToSqlNameEquals("TESTLOWERCASE", "testlowercase");
+        assertToSqlNameEquals("TESTUPPERCASE", "TESTUPPERCASE");
     }
 
     @Test
     public void testToSQLNameUnderscore() {
-        assertEquals("TEST_UNDERSCORE", NamingHelper.toSQLNameDefault("testUnderscore"));
-        assertEquals("AB_CD", NamingHelper.toSQLNameDefault("AbCd"));
-        assertEquals("AB_CD", NamingHelper.toSQLNameDefault("ABCd"));
-        assertEquals("AB_CD", NamingHelper.toSQLNameDefault("AbCD"));
-        assertEquals("SOME_DETAILS_OBJECT", NamingHelper.toSQLNameDefault("SomeDetailsObject"));
+        assertToSqlNameEquals("TEST_UNDERSCORE", "testUnderscore");
+        assertToSqlNameEquals("AB_CD", "AbCd");
+        assertToSqlNameEquals("AB_CD", "ABCd");
+        assertToSqlNameEquals("AB_CD", "AbCD");
+        assertToSqlNameEquals("SOME_DETAILS_OBJECT", "SomeDetailsObject");
+        assertToSqlNameEquals("H_OL_A","hOlA");
+        assertToSqlNameEquals("A","a");
     }
 
+    /**
+     * helper method that asserts the a CamelCase string is converted to UPPER_CASE_UNDER_SCORE correctly
+     * @param expected a camel cased string
+     * @param actual the expected UPPER_CASE_UNDER_SCORE string
+     */
+    private static void assertToSqlNameEquals(String expected, String actual){
+        assertEquals(expected, NamingHelper.toSQLNameDefault(actual));
+    }
 
 }


### PR DESCRIPTION
1. Added documentation to toSQLNameDefault, toSQLName(Field) and
   toSQLName(Class)
2. Rewrote toSQLNameDefault as implementation was hard to understand
   (refactored to make it more readable)
3. Added additional test cases to NamingHelper and created helper method
   assertToSqlNameEquals(String,String) this helps make the test case
   more readable.

**Note:** I plan to add more documentation + tests where possible but before I do more work I want to know if this is something you guys actually want. By the way created an issue as I have not been able to properly configure Android Studio with Sugar, I have more or less set it up but as of right now I cannot run the tests.
