### PR TITLE
delete all should truncate the sequence id as well

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -23,6 +23,8 @@ public class SugarRecord {
         SugarDb db = getSugarContext().getSugarDb();
         SQLiteDatabase sqLiteDatabase = db.getDB();
         sqLiteDatabase.delete(NamingHelper.toSQLName(type), null, null);
+        // added to clear the SQLlite Sequence
+        sqLiteDatabase.delete("sqlite_sequence", "where name=?", NamingHelper.toSQLName(type));
     }
 
     public static <T> void deleteAll(Class<T> type, String whereClause, String... whereArgs) {


### PR DESCRIPTION
hiya, for my app, i am using SQLite as cache, which I update everytime I refresh, while i do a delete all and it works the sequence id keeps increasing. I want to be able to reset the sequence id as well when i do a delete all with no conditions.