### PR TITLE
handle byte[] data value for blob fields

### DIFF
--- a/library/src/com/orm/util/ReflectionUtil.java
+++ b/library/src/com/orm/util/ReflectionUtil.java
@@ -94,6 +94,8 @@ public class ReflectionUtil {
                     } catch (NullPointerException e) {
                         values.put(columnName, (Long) null);
                     }
+                } else if (columnType == byte[].class && columnValue != null && columnValue instanceof byte[]) { // fix: handle byte[] for blob data
+                    values.put(columnName, (byte[])columnValue);
                 } else {
                     if (columnValue == null) {
                         values.putNull(columnName);


### PR DESCRIPTION
Current version converts values for column of type byte[] into a String because of:
```java
values.put(columnName, String.valueOf(columnValue));
```

This fix saves the value properly into a blob. I didn't make test case, but I tested it in my project and it's working.
Thank you.