### PR TITLE
Throw exception inside transaction

### DIFF
--- a/library/src/com/orm/SugarTransactionHelper.java
+++ b/library/src/com/orm/SugarTransactionHelper.java
@@ -5,7 +5,7 @@ import android.util.Log;
 
 public class SugarTransactionHelper {
 
-    public static void doInTansaction(SugarTransactionHelper.Callback callback) {
+    public static void doInTansaction(SugarTransactionHelper.Callback callback) throws Throwable {
         SQLiteDatabase database = SugarContext.getSugarContext().getSugarDb().getDB();
         database.beginTransaction();
 


### PR DESCRIPTION
If an exception happens during a transaction, throw it so it can be handled by the method that initiated the transaction.
