### PR TITLE
robolectric-sugarorm test failure on "table already exists"

### DIFF
--- a/library/src/com/orm/util/ReflectionUtil.java
+++ b/library/src/com/orm/util/ReflectionUtil.java
@@ -244,8 +244,8 @@ public class ReflectionUtil {
         } catch (NullPointerException e) {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             Enumeration<URL> urls = classLoader.getResources("");
-            List<String> fileNames = new ArrayList<String>();
             while (urls.hasMoreElements()) {
+                List<String> fileNames = new ArrayList<String>();
                 String classDirectoryName = urls.nextElement().getFile();
                 if (classDirectoryName.contains("bin") || classDirectoryName.contains("classes")) {
                     File classDirectory = new File(classDirectoryName);


### PR DESCRIPTION
IF you run tobolectric test from command line via gradle tests fails with "already exists" error, this error is casued by the fact that when
robolectric tests are run there are 2 java pathes on context
app/build/intermediates/classes/debug/  and
app/build/test-classes/debug/

This bug caused all clases that are found  under first director yto appear twice, which caused sugarorm to try and create the same tables twice which lead to failure.

I`m pretty sure that fixes the error, but i could not compile it to create a jar, how i produce a jar from this ? 
