### PR TITLE
Fixing issue #201 - NoSuchFieldException on save()

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -190,7 +190,7 @@ public class SugarRecord {
                 SQLiteDatabase.CONFLICT_REPLACE);
 
         if (SugarRecord.class.isAssignableFrom(object.getClass())) {
-            ReflectionUtil.setFieldValueForId(object, id);
+            ((SugarRecord) object).setId(id);
         }
         Log.i("Sugar", object.getClass().getSimpleName() + " saved : " + id);
 


### PR DESCRIPTION
Fixing issue #201 where we would get a NoSuchFieldException on save() when trying to set the id to a subclass of SugarRecord. Used casting instead of reflection for performance.