### PR TITLE
Added support for object cache

### DIFF
--- a/library/src/com/orm/ObjectCache.java
+++ b/library/src/com/orm/ObjectCache.java
@@ -1,0 +1,186 @@
+package com.orm;
+
+import java.lang.ref.Reference;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache which stores objects with a {@link WeakReference} or {@link SoftReference} to them. Java Garbage
+ * Collection can then free these objects if no one has a "strong" reference to the object (weak) or if it runs out of
+ * memory (soft).
+ * 
+ * This class has been borrowed from ORMLITE project (ReferenceObjectCache class)
+ * Project page: http://ormlite.com/
+ * Original code: http://sourceforge.net/p/ormlite/code/HEAD/tree/ormlite-core/trunk/src/main/java/com/j256/ormlite/dao/ReferenceObjectCache.java
+ * 
+ * @author graywatson
+ */
+public class ObjectCache {
+
+	private final ConcurrentHashMap<Class<?>, Map<Object, Reference<Object>>> classMaps =
+			new ConcurrentHashMap<Class<?>, Map<Object, Reference<Object>>>();
+	private final boolean useWeak;
+
+	/**
+	 * @param useWeak
+	 *            Set to true if you want the cache to use {@link WeakReference}. If false then the cache will use
+	 *            {@link SoftReference}.
+	 */
+	public ObjectCache(boolean useWeak) {
+		this.useWeak = useWeak;
+	}
+
+	/**
+	 * Create and return an object cache using {@link WeakReference}.
+	 */
+	public static ObjectCache makeWeakCache() {
+		return new ObjectCache(true);
+	}
+
+	/**
+	 * Create and return an object cache using {@link SoftReference}.
+	 */
+	public static ObjectCache makeSoftCache() {
+		return new ObjectCache(false);
+	}
+	
+	/**
+	 * @param clazz
+	 * @return true if the class is registered
+	 */
+	public <T> boolean isClassRegistered(Class<T> clazz) {
+		return classMaps.get(clazz) != null;
+	}
+
+	public synchronized <T> void registerClass(Class<T> clazz) {
+		Map<Object, Reference<Object>> objectMap = classMaps.get(clazz);
+		if (objectMap == null) {
+			objectMap = new ConcurrentHashMap<Object, Reference<Object>>();
+			classMaps.put(clazz, objectMap);
+		}
+	}
+
+	public <T, ID> T get(Class<T> clazz, ID id) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap == null) {
+			return null;
+		}
+		Reference<Object> ref = objectMap.get(id);
+		if (ref == null) {
+			return null;
+		}
+		Object obj = ref.get();
+		if (obj == null) {
+			objectMap.remove(id);
+			return null;
+		} else {
+			@SuppressWarnings("unchecked")
+			T castObj = (T) obj;
+			return castObj;
+		}
+	}
+
+	public <T, ID> void put(Class<T> clazz, ID id, T data) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap != null) {
+			if (useWeak) {
+				objectMap.put(id, new WeakReference<Object>(data));
+			} else {
+				objectMap.put(id, new SoftReference<Object>(data));
+			}
+		}
+	}
+
+	public <T> void clear(Class<T> clazz) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap != null) {
+			objectMap.clear();
+		}
+	}
+
+	public void clearAll() {
+		for (Map<Object, Reference<Object>> objectMap : classMaps.values()) {
+			objectMap.clear();
+		}
+	}
+
+	public <T, ID> void remove(Class<T> clazz, ID id) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap != null) {
+			objectMap.remove(id);
+		}
+	}
+
+	public <T, ID> T updateId(Class<T> clazz, ID oldId, ID newId) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap == null) {
+			return null;
+		}
+		Reference<Object> ref = objectMap.remove(oldId);
+		if (ref == null) {
+			return null;
+		}
+		objectMap.put(newId, ref);
+		@SuppressWarnings("unchecked")
+		T castObj = (T) ref.get();
+		return castObj;
+	}
+
+	public <T> int size(Class<T> clazz) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap == null) {
+			return 0;
+		} else {
+			return objectMap.size();
+		}
+	}
+
+	public int sizeAll() {
+		int size = 0;
+		for (Map<Object, Reference<Object>> objectMap : classMaps.values()) {
+			size += objectMap.size();
+		}
+		return size;
+	}
+
+	/**
+	 * Run through the map and remove any references that have been null'd out by the GC.
+	 */
+	public <T> void cleanNullReferences(Class<T> clazz) {
+		Map<Object, Reference<Object>> objectMap = getMapForClass(clazz);
+		if (objectMap != null) {
+			cleanMap(objectMap);
+		}
+	}
+
+	/**
+	 * Run through all maps and remove any references that have been null'd out by the GC.
+	 */
+	public <T> void cleanNullReferencesAll() {
+		for (Map<Object, Reference<Object>> objectMap : classMaps.values()) {
+			cleanMap(objectMap);
+		}
+	}
+
+	private void cleanMap(Map<Object, Reference<Object>> objectMap) {
+		Iterator<Entry<Object, Reference<Object>>> iterator = objectMap.entrySet().iterator();
+		while (iterator.hasNext()) {
+			if (iterator.next().getValue().get() == null) {
+				iterator.remove();
+			}
+		}
+	}
+
+	private Map<Object, Reference<Object>> getMapForClass(Class<?> clazz) {
+		Map<Object, Reference<Object>> objectMap = classMaps.get(clazz);
+		if (objectMap == null) {
+			return null;
+		} else {
+			return objectMap;
+		}
+	}
+}

--- a/library/src/com/orm/SugarDb.java
+++ b/library/src/com/orm/SugarDb.java
@@ -1,5 +1,7 @@
 package com.orm;
 
+import static com.orm.util.ManifestHelper.getDatabaseVersion;
+import static com.orm.util.ManifestHelper.getDebugEnabled;
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -7,18 +9,17 @@ import android.database.sqlite.SQLiteOpenHelper;
 import com.orm.util.ManifestHelper;
 import com.orm.util.SugarCursorFactory;
 
-import static com.orm.util.ManifestHelper.getDatabaseVersion;
-import static com.orm.util.ManifestHelper.getDebugEnabled;
-
 public class SugarDb extends SQLiteOpenHelper {
 
     private final SchemaGenerator schemaGenerator;
     private SQLiteDatabase sqLiteDatabase;
+    private ObjectCache objectCache;
 
     public SugarDb(Context context) {
         super(context, ManifestHelper.getDatabaseName(context),
                 new SugarCursorFactory(getDebugEnabled(context)), getDatabaseVersion(context));
         schemaGenerator = new SchemaGenerator(context);
+        enableObjectCache(ManifestHelper.getObjectCacheEnabled(context));
     }
 
     @Override
@@ -39,4 +40,70 @@ public class SugarDb extends SQLiteOpenHelper {
         return this.sqLiteDatabase;
     }
 
+    /**
+     * Enable or disable the object cache for this database.
+     * 
+     * Upon disabling, the cache is cleared
+     * 
+     * @param enable true to enable the cache
+     */
+    public void enableObjectCache(boolean enable) {
+    	if (enable) {
+			if (objectCache == null) {
+				objectCache = ObjectCache.makeWeakCache();
+			}
+		} else {
+			if (objectCache != null) {
+				objectCache.clearAll();
+				objectCache = null;
+			}
+		}
+    }
+    
+    /**
+     * Read the object with the specified class and id from the cache
+     * 
+     * @param clazz
+     * @param id
+     * @return the object if it exists or null otherwise
+     */
+    public <T,ID> T getFromCache(Class<T> clazz, ID id) {
+    	if (objectCache != null && id != null) return objectCache.get(clazz, id);
+    	return null;
+    }
+    
+    /**
+     * Put the record in cache if it has been stored in  the database and the cache is
+     * enabled
+     * 
+     * @param clazz
+     * @param id record id
+     * @param record sugar record
+     */
+    public <T extends Object,ID> void putInCache(Class<T> clazz, ID id, T record) {
+    	if (objectCache == null) return;
+    	if (record == null || id == null) return;
+    	if (!objectCache.isClassRegistered(clazz)) objectCache.registerClass(clazz);
+    	objectCache.put(clazz, id, record);
+    }
+    
+    /**
+     * Remove the record with the specified id and class from the cache
+     * 
+     * @param clazz
+     * @param id
+     */
+    public <T,ID> void removeFromCache(Class<T> clazz, ID id) {
+    	if (objectCache == null || id == null) return;
+    	objectCache.remove(clazz, id);
+    }
+    
+    /**
+     * Remove all records from the specified class from the cache
+     * @param clazz
+     */
+    public <T> void removeFromCache(Class<T> clazz) {
+    	if (objectCache == null) return;
+    	objectCache.clear(clazz);
+    }
 }

--- a/library/src/com/orm/util/ManifestHelper.java
+++ b/library/src/com/orm/util/ManifestHelper.java
@@ -15,11 +15,12 @@ public class ManifestHelper {
      */
     public final static String METADATA_DATABASE = "DATABASE";
     /**
-     * Key for the database verison meta data.
+     * Key for the database version meta data.
      */
     public final static String METADATA_VERSION = "VERSION";
     public final static String METADATA_DOMAIN_PACKAGE_NAME = "DOMAIN_PACKAGE_NAME";
     public final static String METADATA_QUERY_LOG = "QUERY_LOG";
+    public final static String METADATA_OBJECT_CACHE = "OBJECT_CACHE";
     /**
      * The default name for the database unless specified in the AndroidManifest.
      */
@@ -83,6 +84,16 @@ public class ManifestHelper {
      */
     public static boolean getDebugEnabled(Context context) {
         return getMetaDataBoolean(context, METADATA_QUERY_LOG);
+    }
+    
+    /**
+     * Grabs the object cache flag from the manifest.
+     *
+     * @param context  the {@link android.content.Context} of the Android application
+     * @return true if the object cache flag is enabled
+     */
+    public static boolean getObjectCacheEnabled(Context context) {
+    	return getMetaDataBoolean(context, METADATA_OBJECT_CACHE);
     }
 
     private static String getMetaDataString(Context context, String name) {

--- a/library/src/com/orm/util/ReflectionUtil.java
+++ b/library/src/com/orm/util/ReflectionUtil.java
@@ -175,11 +175,30 @@ public class ReflectionUtil {
             Log.e("field set error", e.getMessage());
         }
     }
+    
+    /**
+     * Lookup a field in the specified class and all the superclasses
+     * 
+     * @param cls
+     * @param name
+     * @return
+     * @throws NoSuchFieldException
+     */
+    public static Field getField(Class<?> cls, String name) throws NoSuchFieldException {
+    	try {
+    		Field field = cls.getDeclaredField(name);
+    		return field;
+        } catch (NoSuchFieldException e) {
+        	if (cls.getSuperclass() != null)
+        		return getField(cls.getSuperclass(), name);
+        	throw e;
+        }
+    }
 
     public static void setFieldValueForId(Object object, Long value) {
 
         try {
-            Field field = object.getClass().getField("id");
+            Field field = getField(object.getClass(), "id");
 
             field.setAccessible(true);
             field.set(object, value);
@@ -188,6 +207,20 @@ public class ReflectionUtil {
         } catch (NoSuchFieldException e) {
             e.printStackTrace();
         }
+    }
+    
+    public static Long getFieldValueForId(Object object) {
+    	try {
+            Field field = getField(object.getClass(), "id");
+
+            field.setAccessible(true);
+            return field.getLong(object);
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+    	return null;
     }
 
     public static List<Class> getDomainClasses(Context context) {


### PR DESCRIPTION
Object cache allows that every instance of a database record as an object references the same object.
This allows multiple threads to share a record instance

ObjectCache is implemented using weak reference, therefore when the object is no longer referenced directly
the GC will release it.

The object cache is disabled by default and can be enabled by using OBJECT_CACHE true in the manifest.