### PR TITLE
Allow saving byte values to database

### DIFF
--- a/library/src/com/orm/util/ReflectionUtil.java
+++ b/library/src/com/orm/util/ReflectionUtil.java
@@ -94,6 +94,8 @@ public class ReflectionUtil {
                     } catch (NullPointerException e) {
                         values.put(columnName, (Long) null);
                     }
+                } else if (columnType.getName().equals("[B")) {
+                	values.put(columnName, (byte []) columnValue);
                 } else {
                     if (columnValue == null) {
                         values.putNull(columnName);


### PR DESCRIPTION
Implemented support for `byte []` storage to database. 

Currently `byte []` is supported by definition, but there was no way to store a `byte []` on database 