### PR TITLE
Fixes populating of relationship fields.

### DIFF
--- a/library/src/com/orm/SugarRecord.java
+++ b/library/src/com/orm/SugarRecord.java
@@ -201,9 +201,10 @@ public class SugarRecord {
         List<Field> columns = ReflectionUtil.getTableFields(object.getClass());
 
         for (Field field : columns) {
-            if (field.getClass().isAnnotationPresent(Table.class)) {
+            if (field.getType().isAnnotationPresent(Table.class)) {
                 try {
                     long id = cursor.getLong(cursor.getColumnIndex(NamingHelper.toSQLName(field)));
+                    field.setAccessible(true);
                     field.set(object, (id > 0) ? findById(field.getType(), id) : null);
                 } catch (IllegalAccessException e) {
                     e.printStackTrace();


### PR DESCRIPTION
 * field.getClass() is the wrong place to check for the Table
   annotation. Must look at field.getType()
 * field must be accessible before we can set the object.