### PR TITLE
Added ability to inject settings from application object on startup

### DIFF
--- a/library/src/com/orm/SugarApp.java
+++ b/library/src/com/orm/SugarApp.java
@@ -7,6 +7,7 @@ public class SugarApp extends android.app.Application{
 
     public void onCreate(){
         super.onCreate();
+        SugarConfig.loadDefaults(this);
         SugarApp.sugarContext = this;
         this.database = new Database(this);
     }
@@ -24,5 +25,18 @@ public class SugarApp extends android.app.Application{
 
     protected Database getDatabase() {
         return database;
+    }
+
+    protected void setDatabasePassword(String encryptionKey) {
+        SugarConfig.setDatabasePassword(encryptionKey);
+    }
+    protected void setDBVersion(Integer version) {
+        SugarConfig.setDatabaseVersion(version);
+    }
+    protected void setDomainPackageName(String packageName) {
+        SugarConfig.setDomainPackageName(packageName);
+    }
+    protected void setDatabaseName(String databaseName) {
+        SugarConfig.setDatabaseName(databaseName);
     }
 }

--- a/library/src/com/orm/SugarConfig.java
+++ b/library/src/com/orm/SugarConfig.java
@@ -15,13 +15,44 @@ public class SugarConfig {
 
     static Map<Class<?>, List<Field>> fields = new HashMap<Class<?>, List<Field>>();
 
+    private static String databasePassword = "DEFAULT_ENCRYPTION_KEY";
+    private static Integer databaseVersion = 1;
+    private static String databaseName = "Sugar.db";
+    private static String domainPackageName = "";
+
+    private static boolean databasePasswordSet = false;
+    private static boolean databaseVersionSet = false;
+    private static boolean databaseNameSet = false;
+    private static boolean domainPackageNameSet = false;
+
+    public static void loadDefaults(Context context) {
+        if(!databaseVersionSet) databaseVersion = getMetaDataInteger(context, "VERSION");
+        if(!databasePasswordSet) databasePassword = getMetaDataString(context, "ENCRYPTION_KEY");
+        if(!domainPackageNameSet) domainPackageName = getMetaDataString(context, "DOMAIN_PACKAGE_NAME");
+        if(!databaseNameSet) databaseName = getMetaDataString(context, "DATABASE");
+    }
+
+    public static void setDatabasePassword(String encryptionKey) {
+        databasePassword = encryptionKey;
+        databasePasswordSet = true;
+    }
+
+    public static void setDatabaseVersion(Integer version) {
+        databaseVersion = version;
+        databaseVersionSet = true;
+    }
+
+    public static void setDatabaseName(String dbName) {
+        databaseName = dbName;
+        databaseNameSet = true;
+    }
+
+    public static void setDomainPackageName(String packageName) {
+        domainPackageName = packageName;
+        domainPackageNameSet = true;
+    }
+
     public static String getDatabaseName(Context context) {
-        String databaseName = getMetaDataString(context, "DATABASE");
-
-        if (databaseName == null) {
-            databaseName = "Sugar.db";
-        }
-
         return databaseName;
     }
 
@@ -45,32 +76,14 @@ public class SugarConfig {
     }
 
     public static int getDatabaseVersion(Context context) {
-        Integer databaseVersion = getMetaDataInteger(context, "VERSION");
-
-        if ((databaseVersion == null) || (databaseVersion == 0)) {
-            databaseVersion = 1;
-        }
-
         return databaseVersion;
     }
 
     public static String getDatabasePassword(Context context) {
-        String encryptionKey = getMetaDataString(context, "ENCRYPTION_KEY");
-
-        if ((encryptionKey == null) || (encryptionKey.trim().equals(""))) {
-            encryptionKey = "DEFAULT_ENCRYPTION_KEY";
-        }
-
-        return encryptionKey;
+        return databasePassword;
     }
 
     public static String getDomainPackageName(Context context){
-        String domainPackageName = getMetaDataString(context, "DOMAIN_PACKAGE_NAME");
-
-        if (domainPackageName == null) {
-            domainPackageName = "";
-        }
-
         return domainPackageName;
     }
 

--- a/library/src/com/orm/SugarDb.java
+++ b/library/src/com/orm/SugarDb.java
@@ -3,7 +3,7 @@ package com.orm;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.util.Log;
-import dalvik.system.DexFile;
+
 import net.sqlcipher.database.SQLiteDatabase;
 import net.sqlcipher.database.SQLiteException;
 import net.sqlcipher.database.SQLiteOpenHelper;
@@ -15,16 +15,21 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
-import static com.orm.SugarConfig.getDatabaseVersion;
+import dalvik.system.DexFile;
+
 import static com.orm.SugarConfig.getDebugEnabled;
 
 public class SugarDb extends SQLiteOpenHelper {
     private Context context;
 
     public SugarDb(Context context) {
-        super(context, SugarConfig.getDatabaseName(context), new SugarCursorFactory(getDebugEnabled(context)), getDatabaseVersion(context));
+        super(context, SugarConfig.getDatabaseName(context), new SugarCursorFactory(getDebugEnabled(context)), SugarConfig.getDatabaseVersion(context));
         this.context = context;
 
     }


### PR DESCRIPTION
This allows the user to inject the library settings (such as the encryption key) to be injected to the application on startup instead of being stored in the manifest file as requested by several users, including myself.