### PR TITLE
Fix StrictMode crashes by calling `close` on our DexFiles

### DIFF
--- a/library/src/main/java/com/orm/util/ReflectionUtil.java
+++ b/library/src/main/java/com/orm/util/ReflectionUtil.java
@@ -291,8 +291,9 @@ public class ReflectionUtil {
         String packageName = ManifestHelper.getDomainPackageName(context);
         String path = getSourcePath(context);
         List<String> classNames = new ArrayList<String>();
+        DexFile dexfile = null;
         try {
-            DexFile dexfile = new DexFile(path);
+            dexfile = new DexFile(path);
             Enumeration<String> dexEntries = dexfile.entries();
             while (dexEntries.hasMoreElements()) {
                 String className = dexEntries.nextElement();
@@ -314,6 +315,8 @@ public class ReflectionUtil {
                     }
                 }
             }
+        } finally {
+            if (null != dexfile) dexfile.close();
         }
         return classNames;
     }


### PR DESCRIPTION
When we [enable StictMode](http://developer.android.com/reference/android/os/StrictMode.html), sugar occasionally throws the following sort of error:

```
java.lang.Throwable: Explicit termination method 'close' not called
	at dalvik.system.CloseGuard.open(CloseGuard.java:184)
	at dalvik.system.DexFile.<init>(DexFile.java:82)
	at com.orm.util.ReflectionUtil.getAllClasses(ReflectionUtil.java:295)
	at com.orm.util.ReflectionUtil.getDomainClasses(ReflectionUtil.java:253)
	at com.orm.SchemaGenerator.createDatabase(SchemaGenerator.java:37)
	at com.orm.SugarDb.onCreate(SugarDb.java:26)
	at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:251)
	at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:163)
	at com.orm.SugarDb.getDB(SugarDb.java:36)
	at com.orm.SugarRecord.find(SugarRecord.java:189)
	[snip]
```

This is because instances of DexFile need to be closed when they're no longer needed. This patch cleans up resources to fix the crashing case.