### PR TITLE
Sugar 1.4

### DIFF
--- a/library/.settings/org.eclipse.jdt.core.prefs
+++ b/library/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.source=1.6

--- a/library/src/com/orm/SugarApp.java
+++ b/library/src/com/orm/SugarApp.java
@@ -1,28 +1,11 @@
 package com.orm;
 
-public class SugarApp extends android.app.Application{
+import android.content.Context;
+
+public class SugarApp{
 
     private Database database;
     private static SugarApp sugarContext;
-
-    public void onCreate(){
-        super.onCreate();
-        SugarApp.sugarContext = this;
-        this.database = new Database(this);
-    }
-
-    /*
-     * Per issue #106 on Github, this method won't be called in
-     * any real Android device. This method is used purely in
-     * emulated process environments such as an emulator or
-     * Robolectric Android mock.
-     */
-    public void onTerminate(){
-        if (this.database != null) {
-            this.database.getDB().close();
-        }
-        super.onTerminate();
-    }
 
     public static SugarApp getSugarContext(){
         return sugarContext;
@@ -30,5 +13,26 @@ public class SugarApp extends android.app.Application{
 
     protected Database getDatabase() {
         return database;
+    }
+    
+    private SugarApp(){
+    	
+    }
+
+    /**
+     * Initializes Sugar ORM. It should be initialized in Application class.
+     * @param context applicatinContext
+     */
+    public static void init(Context context){
+    	sugarContext = new SugarApp();
+    	sugarContext.database = new Database(context);
+    }
+    /**
+     * Closes sugar DB connection.
+     */
+    public static void closeDB(){
+    	if(sugarContext.database != null){
+    		sugarContext.database.getDB().close();
+    	}
     }
 }


### PR DESCRIPTION
Dependency to extend SugarApp class is removed. SugarApp.init(Context) has to be called in app's Application class