### PR TITLE
Prevent NoClassDefFoundError crashing app using Sugar

### DIFF
--- a/library/src/main/java/com/orm/util/ReflectionUtil.java
+++ b/library/src/main/java/com/orm/util/ReflectionUtil.java
@@ -268,7 +268,7 @@ public class ReflectionUtil {
         Class<?> discoveredClass = null;
         try {
             discoveredClass = Class.forName(className, true, context.getClass().getClassLoader());
-        } catch (ClassNotFoundException e) {
+        } catch (Throwable e) {
             Log.e("Sugar", e.getMessage());
         }
 


### PR DESCRIPTION
Hi Satya,

I'm just getting started using Sugar ORM and it looks really good so far.  However, I had trouble getting my app to run because I kept getting a NoClassDefFoundError when I included Sugar.

I had a jar file on my classpath which wasn't actually being used by the project.  When Sugar tried to load a class from that library, my app crashed.

My guess is that because the library was not being used, the classes didn't actually get copied to the apk, or something like that.

I changed the catch clause in getDomainClass to catch all throwables.  It doesn't seem to matter why we can't load a class, the result will be the same: if there is an error of any kind, we're not going to be able to use that class as a domain class.

Thanks,

Alex