### PR TITLE
Add MultiColumn Unique Table constraint support

### DIFF
--- a/library/src/main/java/com/orm/SchemaGenerator.java
+++ b/library/src/main/java/com/orm/SchemaGenerator.java
@@ -18,6 +18,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -151,6 +152,24 @@ public class SchemaGenerator {
                     }
                 }
             }
+        }
+
+        if (table.isAnnotationPresent(Unique.class)) {
+            String constraint = table.getAnnotation(Unique.class).value();
+
+            sb.append(", UNIQUE(");
+
+            String[] constraintFields = constraint.split(",");
+            for(int i = 0; i < constraintFields.length; i++) {
+                String columnName = NamingHelper.toSQLNameDefault(constraintFields[i]);
+                sb.append(columnName);
+
+                if(i < (constraintFields.length -1)) {
+                    sb.append(",");
+                }
+            }
+
+            sb.append(") ON CONFLICT REPLACE");
         }
 
         sb.append(" ) ");

--- a/library/src/main/java/com/orm/dsl/Unique.java
+++ b/library/src/main/java/com/orm/dsl/Unique.java
@@ -5,4 +5,5 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Unique {
+    String value();
 }


### PR DESCRIPTION
Reused the Unique constraint on the Table, to provide a qui way to implement unique constraints across multiple fields. It's a rather simple approach, but gets the job done.

```
@Unique("a, b")
public class IntegerUniqueAnnotatedModel extends SugarRecord {

    private int a;
    private int b;

    public IntegerUniqueAnnotatedModel() {}

    public IntegerUniqueAnnotatedModel(int a, int b) {
        this.a = a;
        this.b = b;
    }

    public int getA() { return a; }
    public int getB() { return b; }
}
```

  