### PR TITLE
fix Travis CI build for Build Tools 23.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: android
 android:
   components:
     - sys-img-armeabi-v7a-android-23
+    - tools
     - build-tools-23.0.2
     - android-23
 


### PR DESCRIPTION
Added `tools` to .travis.yml so the Travis CI build can succeed with Build Tools 23.0.2 -- c.f. travis-ci/travis-ci#5036