### PR TITLE
Comments on migrations files

### DIFF
--- a/library/src/main/java/com/orm/SchemaGenerator.java
+++ b/library/src/main/java/com/orm/SchemaGenerator.java
@@ -10,6 +10,7 @@ import com.orm.dsl.Column;
 import com.orm.dsl.MultiUnique;
 import com.orm.dsl.NotNull;
 import com.orm.dsl.Unique;
+import com.orm.util.MigrationFileParser;
 import com.orm.util.NamingHelper;
 import com.orm.util.NumberComparator;
 import com.orm.util.QueryBuilder;
@@ -98,11 +99,16 @@ public class SchemaGenerator {
         try {
             InputStream is = this.context.getAssets().open("sugar_upgrades/" + file);
             BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            StringBuilder sb = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
-                Log.i("Sugar script", line);
-                db.execSQL(line);
+                sb.append(line);
             }
+            MigrationFileParser migrationFileParser = new MigrationFileParser(sb.toString());
+            for(String statement: migrationFileParser.getStatements()){
+                db.execSQL(statement);
+            }
+
         } catch (IOException e) {
             Log.e(SUGAR, e.getMessage());
         }

--- a/library/src/main/java/com/orm/SchemaGenerator.java
+++ b/library/src/main/java/com/orm/SchemaGenerator.java
@@ -106,6 +106,7 @@ public class SchemaGenerator {
             }
             MigrationFileParser migrationFileParser = new MigrationFileParser(sb.toString());
             for(String statement: migrationFileParser.getStatements()){
+                Log.i("Sugar script", statement);
                 db.execSQL(statement);
             }
 

--- a/library/src/main/java/com/orm/SugarContext.java
+++ b/library/src/main/java/com/orm/SugarContext.java
@@ -10,11 +10,9 @@ public class SugarContext {
 
     private static SugarContext instance = null;
     private SugarDb sugarDb;
-    private Context context;
     private Map<Object, Long> entitiesMap;
 
     private SugarContext(Context context) {
-        this.context = context;
         this.sugarDb = new SugarDb(context);
         this.entitiesMap = Collections.synchronizedMap(new WeakHashMap<Object, Long>());
     }

--- a/library/src/main/java/com/orm/util/MigrationFileParser.java
+++ b/library/src/main/java/com/orm/util/MigrationFileParser.java
@@ -1,0 +1,21 @@
+package com.orm.util;
+
+/**
+ * Created by Nursultan Turdaliev on 12/4/15.
+ */
+public class MigrationFileParser {
+
+    private String content;
+
+    /**
+     * @param content
+     */
+    public MigrationFileParser(String content){
+        this.content = content.replaceAll("(\\/\\*([\\s\\S]*?)\\*\\/)|(--(.)*)|(\n)","");
+    }
+
+    public String[] getStatements(){
+        return this.content.split(";");
+    }
+
+}

--- a/library/src/test/java/com/orm/util/MigrationFileParserTest.java
+++ b/library/src/test/java/com/orm/util/MigrationFileParserTest.java
@@ -1,0 +1,48 @@
+package com.orm.util;
+
+import com.orm.util.MigrationFileParser;
+
+import org.junit.Test;
+import org.junit.Before;
+
+import java.lang.String;
+
+import static junit.framework.Assert.assertEquals;
+
+public class MigrationFileParserTest{
+    MigrationFileParser emptyFile;
+
+    @Test
+    public void testSingleLineStatement()
+    {
+        MigrationFileParser singleLineComment = new MigrationFileParser("insert into table--comment");
+
+        String statements[] = singleLineComment.getStatements();
+        assertEquals("Testing single line statement size",1,statements.length);
+        assertEquals("Testing single line statement content","insert into table",statements[0]);
+
+        singleLineComment = new MigrationFileParser("insert into table--comment\n");
+
+        singleLineComment.getStatements();
+        assertEquals("Testing single line statement size",1,statements.length);
+        assertEquals("Testing single line statement content","insert into table",statements[0]);
+    }
+    @Test
+    public void testMultiLineComment(){
+        MigrationFileParser multiLineComment = new MigrationFileParser("insert into table /**comment \n new line 2 \n new line 3 */hello");
+
+        String statements[] = multiLineComment.getStatements();
+        assertEquals("Testing multiline statement size",1,statements.length);
+        assertEquals("Testing multiline comment","insert into table hello",statements[0]);
+    }
+
+    @Test
+    public void testMixedComment(){
+        MigrationFileParser mixedComment = new MigrationFileParser("insert into/*multiline\n **comment*/--comment");
+
+        String statements[] = mixedComment.getStatements();
+
+        assertEquals("Testing mixed comment statement size",1,statements.length);
+        assertEquals("Testing mixed comment statments", "insert into", statements[0]);
+    }
+}


### PR DESCRIPTION
#150 Now it's possible to have comments inside migration files, because of the comments it's not possible to assume that one line is one statement in sqlite query. So Now users should divide the statements with `;` symbol.

I will work on documentation as well.