### PR TITLE
Fixing migration to single dex after multidex.

### DIFF
--- a/library/src/main/java/com/orm/util/MultiDexHelper.java
+++ b/library/src/main/java/com/orm/util/MultiDexHelper.java
@@ -64,9 +64,6 @@ public class MultiDexHelper {
             if (extractedFile.isFile()) {
                 sourcePaths.add(extractedFile.getAbsolutePath());
                 //we ignore the verify zip part
-            } else {
-                throw new IOException("Missing extracted secondary dex file '" +
-                        extractedFile.getPath() + "'");
             }
         }
 


### PR DESCRIPTION
I had a problem where an app was using multidex, then I removed the multidex and I was getting a error because Sugar couldn't find the secondary dex file, so it wasn't creating the tables.

I removed the exception thrown, it will only ignore it if it can't find the other Dex files.