### PR TITLE
Make SugarRecord API more versatile

### DIFF
--- a/library/src/main/java/com/orm/SugarRecord.java
+++ b/library/src/main/java/com/orm/SugarRecord.java
@@ -142,7 +142,7 @@ public class SugarRecord {
         return findById(type, Long.valueOf(id));
     }
 
-    public static <T> List<T> findById(Class<T> type, String[] ids) {
+    public static <T> List<T> findById(Class<T> type, String... ids) {
         String whereClause = "id IN (" + QueryBuilder.generatePlaceholders(ids.length) + ")";
         return find(type, whereClause, ids);
     }
@@ -231,7 +231,7 @@ public class SugarRecord {
         return count(type, null, null, null, null, null);
     }
 
-    public static <T> long count(Class<T> type, String whereClause, String[] whereArgs) {
+    public static <T> long count(Class<T> type, String whereClause, String... whereArgs) {
     	return count(type, whereClause, whereArgs, null, null, null);
     }
 


### PR DESCRIPTION
this should not change the API, but makes it easier to use.
Especially for cases like wanting to count for one specific value,
resulting in a where with only one or a few args.
Currently we need to create a String array for that, resulting in a
ugly new String[]{"bla"} block.
Now it is possible to directly pass "bla"

count was the motivation for this change, but I changed other signatures
where this was possible as well.