### PR TITLE
Add support for Serializable fields

### DIFF
--- a/library/src/main/java/com/orm/util/QueryBuilder.java
+++ b/library/src/main/java/com/orm/util/QueryBuilder.java
@@ -2,6 +2,7 @@ package com.orm.util;
 
 import com.orm.SugarRecord;
 
+import java.io.Serializable;
 import java.lang.RuntimeException;
 import java.lang.StringBuilder;
 import java.math.BigDecimal;
@@ -38,6 +39,10 @@ public class QueryBuilder {
         if ((type.equals(String.class)) || (type.equals(Character.TYPE)) ||
                 (type.equals(BigDecimal.class))) {
             return "TEXT";
+        }
+
+        if(Serializable.class.isAssignableFrom(type)) {
+            return "BLOB";
         }
 
         return "";


### PR DESCRIPTION
The slight addition allows to store into database any object field implementing the Serializable interface in addition to the Java types already supported. For instance, (small) lists or maps of Serializable types can now be stored into database without creating additional models or writing boilerplate serialization/deserialization code to/from BLOB.