### PR TITLE
update record using more than one clause

### DIFF
--- a/library/src/main/java/com/orm/SugarRecord.java
+++ b/library/src/main/java/com/orm/SugarRecord.java
@@ -376,7 +376,7 @@ public class SugarRecord {
                     String columnName = NamingHelper.toColumnName(column);
                     Object columnValue = column.get(object);
 
-                    whereClause.append(columnName).append(" = ?");
+                    whereClause.append(whereClause.toString().contains("?") ? " AND " : "").append(columnName).append(" = ?");
                     whereArgs.add(String.valueOf(columnValue));
                 } catch (IllegalAccessException e) {
                     e.printStackTrace();


### PR DESCRIPTION
As mentioned in #649 I need to update a record using more than one clause. 
Scenario:
an object that has two attributes with `@Unique`, and the time to do an `UPDATE` on table records get the following exception: 
`android.database.sqlite.SQLiteException: near "nome_cidade": syntax error (code 1): , while compiling: UPDATE cidade SET sincronizacao=?,ultima_alteracao=?,ativo=?,hash=?,uf=? WHERE ibge = ?nome_cidade = ?` 
I noticed the following detail on this query `UPDATE`: `... WHERE ibge = ?nome_cidade = ?`. 
Looking well, it notes that should be `... WHERE ibge = ? AND nome_cidade = ?`. 