### PR TITLE
Fix for #632 - put task name inside quotes

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -28,9 +28,8 @@ dependencies {
 }
 
 task libraryJar(type: Jar) {
-    dependsOn assembleRelease
+    dependsOn 'assembleRelease'
     from android.sourceSets.main.java.srcDirs,
          ['build/intermediates/classes/release/'] // Add the release classes into the jar
     baseName 'sugar'
 }
-


### PR DESCRIPTION
Fix for the following error that popped up after upgrading to Gradle 2.2 - 

> Could not find property 'assembleRelease' on task ':sugar:libraryJar'

#632 