### PR TITLE
Manually init classes list

### DIFF
--- a/library/src/main/java/com/orm/SchemaGenerator.java
+++ b/library/src/main/java/com/orm/SchemaGenerator.java
@@ -44,8 +44,8 @@ public class SchemaGenerator {
         return new SchemaGenerator();
     }
 
-    public void createDatabase(SQLiteDatabase sqLiteDatabase) {
-        List<Class> domainClasses = getDomainClasses();
+    public void createDatabase(SQLiteDatabase sqLiteDatabase, List<Class> modelsClasses) {
+        List<Class> domainClasses = modelsClasses == null ? getDomainClasses() : modelsClasses;
         for (Class domain : domainClasses) {
             createTable(domain, sqLiteDatabase);
             afterTableCreated(domain,sqLiteDatabase);
@@ -59,8 +59,8 @@ public class SchemaGenerator {
 
     }
 
-    public void doUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
-        List<Class> domainClasses = getDomainClasses();
+    public void doUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion, List<Class> modelsClasses) {
+        List<Class> domainClasses = modelsClasses == null ? getDomainClasses() : modelsClasses;
         String sql = "select count(*) from sqlite_master where type='table' and name='%s';";
 
         for (Class domain : domainClasses) {

--- a/library/src/main/java/com/orm/SugarApp.java
+++ b/library/src/main/java/com/orm/SugarApp.java
@@ -2,6 +2,8 @@ package com.orm;
 
 import android.app.Application;
 
+import java.util.List;
+
 public class SugarApp extends Application {
 
     @Override
@@ -14,6 +16,10 @@ public class SugarApp extends Application {
     public void onTerminate() {
         super.onTerminate();
         SugarContext.terminate();
+    }
+
+    public List<Class> getModelsClassesList() {
+        return null;
     }
 
 }

--- a/library/src/main/java/com/orm/SugarContext.java
+++ b/library/src/main/java/com/orm/SugarContext.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.orm.util.ContextUtil;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
@@ -15,8 +16,8 @@ public class SugarContext {
     private SugarDb sugarDb;
     private Map<Object, Long> entitiesMap;
 
-    private SugarContext() {
-        this.sugarDb = SugarDb.getInstance();
+    private SugarContext(List<Class> modelsClasses) {
+        this.sugarDb = SugarDb.getInstance(modelsClasses);
         this.entitiesMap = Collections.synchronizedMap(new WeakHashMap<Object, Long>());
     }
     
@@ -29,7 +30,13 @@ public class SugarContext {
 
     public static void init(Context context) {
         ContextUtil.init(context);
-        instance = new SugarContext();
+        instance = new SugarContext(null);
+        dbConfiguration = null;
+    }
+
+    public static void init(Context context, List<Class> modelsClasses) {
+        ContextUtil.init(context);
+        instance = new SugarContext(modelsClasses);
         dbConfiguration = null;
     }
 

--- a/library/src/main/java/com/orm/SugarDb.java
+++ b/library/src/main/java/com/orm/SugarDb.java
@@ -30,6 +30,10 @@ public class SugarDb extends SQLiteOpenHelper {
         schemaGenerator = SchemaGenerator.getInstance();
     }
 
+    public static SugarDb getInstance() {
+        return new SugarDb(null);
+    }
+
     public static SugarDb getInstance(List<Class> modelsClasses) {
         return new SugarDb(modelsClasses);
     }

--- a/library/src/main/java/com/orm/SugarDb.java
+++ b/library/src/main/java/com/orm/SugarDb.java
@@ -8,6 +8,8 @@ import com.orm.dsl.BuildConfig;
 import com.orm.helper.ManifestHelper;
 import com.orm.util.SugarCursorFactory;
 
+import java.util.List;
+
 import static com.orm.util.ContextUtil.getContext;
 import static com.orm.helper.ManifestHelper.getDatabaseVersion;
 import static com.orm.helper.ManifestHelper.getDbName;
@@ -19,15 +21,17 @@ public class SugarDb extends SQLiteOpenHelper {
     private final SchemaGenerator schemaGenerator;
     private SQLiteDatabase sqLiteDatabase;
     private int openedConnections = 0;
+    private List<Class> classes;
 
     //Prevent instantiation
-    private SugarDb() {
+    private SugarDb(List<Class> modelsClasses) {
         super(getContext(), getDbName(), new SugarCursorFactory(ManifestHelper.isDebugEnabled()), getDatabaseVersion());
+        this.classes = modelsClasses;
         schemaGenerator = SchemaGenerator.getInstance();
     }
 
-    public static SugarDb getInstance() {
-        return new SugarDb();
+    public static SugarDb getInstance(List<Class> modelsClasses) {
+        return new SugarDb(modelsClasses);
     }
 
     @Override
@@ -50,7 +54,7 @@ public class SugarDb extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase sqLiteDatabase, int oldVersion, int newVersion) {
-        schemaGenerator.doUpgrade(sqLiteDatabase, oldVersion, newVersion);
+        schemaGenerator.doUpgrade(sqLiteDatabase, oldVersion, newVersion, classes);
     }
 
     public synchronized SQLiteDatabase getDB() {

--- a/library/src/main/java/com/orm/SugarDb.java
+++ b/library/src/main/java/com/orm/SugarDb.java
@@ -36,7 +36,7 @@ public class SugarDb extends SQLiteOpenHelper {
 
     @Override
     public void onCreate(SQLiteDatabase sqLiteDatabase) {
-        schemaGenerator.createDatabase(sqLiteDatabase);
+        schemaGenerator.createDatabase(sqLiteDatabase, classes);
     }
 
     @Override

--- a/library/src/test/java/com/orm/SchemaGeneratorTest.java
+++ b/library/src/test/java/com/orm/SchemaGeneratorTest.java
@@ -131,7 +131,7 @@ public final class SchemaGeneratorTest {
         SQLiteDatabase sqLiteDatabase = SugarContext.getSugarContext().getSugarDb().getDB();
         SchemaGenerator schemaGenerator = SchemaGenerator.getInstance();
 
-        schemaGenerator.createDatabase(sqLiteDatabase);
+        schemaGenerator.createDatabase(sqLiteDatabase, null);
         String sql = "select count(*) from sqlite_master where type='table';";
 
         Cursor c = sqLiteDatabase.rawQuery(sql, null);
@@ -150,7 +150,7 @@ public final class SchemaGeneratorTest {
         SQLiteDatabase sqLiteDatabase = SugarContext.getSugarContext().getSugarDb().getDB();
         SchemaGenerator schemaGenerator = SchemaGenerator.getInstance();
 
-        schemaGenerator.createDatabase(sqLiteDatabase);
+        schemaGenerator.createDatabase(sqLiteDatabase, null);
         schemaGenerator.deleteTables(sqLiteDatabase);
 
         String sql = "select count(*) from sqlite_master where type='table';";


### PR DESCRIPTION
During initialization, SugarOrm parses all the classes in a specified package and finds all SugarRecord classes. This has been problematic in the past because of InstantRun and newest Gradle build tools.

This commit adds a way to manually declare the list of classes we want to convert to tables.
Simply provide a list of Class objects when calling SugarContext.init() or extend SugarApp and its getModelsClassesList() method.
All of this is obviously optional.

Note that no test and no example app has been written for this modification.