### PR TITLE
NoSuchFieldException on delete of persistent model with inherited Id field

### DIFF
--- a/library/src/main/java/com/orm/SugarRecord.java
+++ b/library/src/main/java/com/orm/SugarRecord.java
@@ -423,7 +423,10 @@ public class SugarRecord {
         Class<?> type = object.getClass();
         if (type.isAnnotationPresent(Table.class)) {
             try {
-                Field field = type.getDeclaredField("id");
+                Field field = ReflectionUtil.getFieldByName(type, "id");
+                if(field == null){
+                    throw new NoSuchFieldException();
+                }
                 field.setAccessible(true);
                 Long id = (Long) field.get(object);
                 if (id != null && id > 0L) {

--- a/library/src/main/java/com/orm/util/ReflectionUtil.java
+++ b/library/src/main/java/com/orm/util/ReflectionUtil.java
@@ -40,9 +40,7 @@ public final class ReflectionUtil {
         if (ManifestHelper.isDebugEnabled()) {
             Log.d("Sugar", "Fetching properties");
         }
-        List<Field> typeFields = new ArrayList<>();
-
-        getAllFields(typeFields, table);
+        List<Field> typeFields = getAllFields(table);
 
         List<Field> toStore = new ArrayList<>();
         for (Field field : typeFields) {
@@ -55,14 +53,25 @@ public final class ReflectionUtil {
         return toStore;
     }
 
-    private static List<Field> getAllFields(List<Field> fields, Class<?> type) {
+    public static List<Field> getAllFields(Class<?> type) {
+        List<Field> fields = new ArrayList<>();
         Collections.addAll(fields, type.getDeclaredFields());
 
         if (type.getSuperclass() != null) {
-            fields = getAllFields(fields, type.getSuperclass());
+            fields.addAll(getAllFields(type.getSuperclass()));
         }
 
         return fields;
+    }
+
+    public static Field getFieldByName(Class<?> type, String name) {
+        List<Field> all = getAllFields(type);
+        for(Field field : all){
+            if(field.getName().equals(name)){
+                return field;
+            }
+        }
+        return null;
     }
 
     public static void addFieldValueToColumn(ContentValues values, Field column, Object object,

--- a/library/src/test/java/com/orm/SchemaGeneratorTest.java
+++ b/library/src/test/java/com/orm/SchemaGeneratorTest.java
@@ -137,7 +137,7 @@ public final class SchemaGeneratorTest {
         Cursor c = sqLiteDatabase.rawQuery(sql, null);
 
         if (c.moveToFirst()) {
-            Assert.assertEquals(48, c.getInt(0));
+            Assert.assertEquals(49, c.getInt(0));
         }
 
         if (!c.isClosed()) {

--- a/library/src/test/java/com/orm/model/SimpleModelWithMore.java
+++ b/library/src/test/java/com/orm/model/SimpleModelWithMore.java
@@ -1,0 +1,14 @@
+package com.orm.model;
+
+public class SimpleModelWithMore extends SimpleModel {
+
+    private String more;
+
+    public String getMore() {
+        return more;
+    }
+
+    public void setMore(String more) {
+        this.more = more;
+    }
+}

--- a/library/src/test/java/com/orm/util/ReflectionUtilTest.java
+++ b/library/src/test/java/com/orm/util/ReflectionUtilTest.java
@@ -102,7 +102,7 @@ public final class ReflectionUtilTest {
     @Test
     public void testGetAllClasses() {
         List<Class> classes = ReflectionUtil.getDomainClasses();
-        Assert.assertEquals(46, classes.size());
+        Assert.assertEquals(47, classes.size());
     }
 
     @Test(expected = NoSuchFieldException.class)

--- a/library/src/test/java/com/orm/util/ReflectionUtilTest.java
+++ b/library/src/test/java/com/orm/util/ReflectionUtilTest.java
@@ -7,6 +7,8 @@ import com.orm.SugarContext;
 import com.orm.SugarRecord;
 import com.orm.app.ClientApp;
 import com.orm.dsl.BuildConfig;
+import com.orm.model.SimpleModel;
+import com.orm.model.SimpleModelWithMore;
 import com.orm.model.TestRecord;
 import com.orm.model.foreignnull.OriginRecord;
 import com.orm.query.Select;
@@ -38,14 +40,40 @@ public final class ReflectionUtilTest {
     @Test
     public void testGetTableFields() {
         List<Field> fieldList = ReflectionUtil.getTableFields(TestRecord.class);
-        List<String> strings = new ArrayList<>();
 
-        for (Field field: fieldList) {
-            strings.add(field.getName());
-        }
+        List<String> strings = getStringNamesFromFields(fieldList);
 
         Assert.assertEquals(true, strings.contains("id"));
         Assert.assertEquals(true, strings.contains("name"));
+    }
+
+    @Test
+    public void testGetAllFields() {
+        List<Field> fieldList = ReflectionUtil.getAllFields(SimpleModelWithMore.class);
+
+        List<String> strings = getStringNamesFromFields(fieldList);
+
+        Assert.assertEquals(true, strings.contains("more"));
+        Assert.assertEquals(true, strings.contains("str"));
+        Assert.assertEquals(true, strings.contains("integer"));
+        Assert.assertEquals(true, strings.contains("bool"));
+
+    }
+
+    @Test
+    public void testGetFieldByName() {
+        Field field = ReflectionUtil.getFieldByName(SimpleModel.class, "str");
+        Assert.assertNotNull(field);
+    }
+
+    private List<String> getStringNamesFromFields(List<Field> fieldList) {
+        List<String> strings = new ArrayList<>();
+
+        for (Field field : fieldList) {
+            strings.add(field.getName());
+        }
+
+        return strings;
     }
 
     @Test(expected = NoSuchFieldException.class)
@@ -93,7 +121,7 @@ public final class ReflectionUtilTest {
 
     @Test
     public void testForeignNull() throws NoSuchFieldException {
-        final OriginRecord record = new OriginRecord(null,null);
+        final OriginRecord record = new OriginRecord(null, null);
         SugarRecord.save(record);
     }
 }


### PR DESCRIPTION
In general, Sugar isn't very inheritance friendly.  Coupled with annotated table usage of the library, as I prefer (in order to prevent persistence layer operations living directly in the model itself), you'll run into an issue in the static delete method of the SugarRecord class, `Field field = type.getDeclaredField("id");`
Given that this will ignore inherited fields, where I've used inheritance with the ID residing in the superclass, a `NoSuchFieldException` is thrown.  I've made use of a method already defined ReflectionUtils, and modified an existing (passing an mutable argument in and returning it isn't the best design). 